### PR TITLE
Create Metadata-included annotations

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,6 @@
 from os.path import join as path_join
 default_window_size = 13
-parquets_path = "/content/drive/MyDrive/ActivityNet200/parquets"
+DATASET_DIRPATH = path_join("/", "content", "drive", "MyDrive", "ActivityNet200", "v1-3")
+parquets_path = path_join("/", "content", "drive", "MyDrive", "ActivityNet200", "parquets")
+# DATASET_DIRPATH = path_join("/", "Users", "hgs", "activitynet1.3")
 # parquets_path = path_join('.', 'features_logits')


### PR DESCRIPTION
# Create Metadata-included annotations

기존 annotation 은 fps와 같은 metadata를 가지고 있지 않아 segments 데이터의 초단위에 대해 frame 인덱스의 형태로 변환이 요구되었다. 본 커밋은 csv생성시 fps와 같은 메타데이터를 포함하여 frame 인덱스의 형태로 변환시킬 수 있도록 한다.